### PR TITLE
feat: Change Rendering from appendChild to InnerHtml, Close #9

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1,59 +1,36 @@
-const createRenderBox = (index) => {
-    const box = document.querySelector("#render-box-container");
+const createRenderBox = (index, htmlTag) => {
+    const divTag = `
+    <div class="white-background display-box" id="render-box-${index}">
+        <svg viewBox="0 0 1280 720">
+            <foreignObject width="1280" height="720">
+                <div class="inner-div" id="inner-box-${index}">
+                    ${htmlTag}
+                </div>
+            </foreignObject>
+        </svg>
+    </div>`;
 
-    if (box.childElementCount >= index) {
-        return;
-    }
-
-    const div = document.createElement("div");
-    div.setAttribute("class", "white-background display-box");
-    div.setAttribute("id", `render-box-${index}`);
-
-    div.innerHTML = `
-    <svg viewBox="0 0 1280 720">
-        <foreignObject width="1280" height="720">
-            <div class="inner-div" id="inner-box-${index}"></div>
-        </foreignObject>
-    </svg>`;
-
-    box.appendChild(div);
-};
-
-const getInnerBox = (index) => {
-    return document.querySelector(`#inner-box-${index}`);
-};
-
-const setBox = () => {
-    const box = document.querySelector("#render-box-container");
-    const size = box.childElementCount;
-
-    for (let i = size; i > 1; i--) {
-        box.removeChild(box.childNodes[i]);
-    }
+    return divTag;
 };
 
 export const renderer = (tokens) => {
-    setBox();
-    let index = 1;
-
-    let innerBox = getInnerBox(index);
-    innerBox.innerHTML = "";
+    let count = 1;
 
     let htmlTag = "";
+    let boxInnerTag = "";
 
     tokens.forEach((data) => {
         if (data.tag === "<hr/>") {
-            index++;
+            count++;
 
-            innerBox.innerHTML = htmlTag;
+            const divTag = createRenderBox(count, htmlTag);
+            boxInnerTag += divTag;
             htmlTag = "";
-
-            createRenderBox(index);
-            innerBox = getInnerBox(index);
-            innerBox.innerHTML = "";
         } else {
             htmlTag += data.tag;
         }
     });
-    innerBox.innerHTML = htmlTag;
+    boxInnerTag += createRenderBox(count, htmlTag);
+    const box = document.querySelector("#render-box-container");
+    box.innerHTML = boxInnerTag;
 };


### PR DESCRIPTION
기존의 키 입력시 마다 Dom을 조작하여 RemoveChild 및 AppendChild를 계속 실행시켜주는 것에서 파싱한 결과를 한번에 InnerHtml로 만들어주는것으로 변경하였음.

계속해서 한 문단마다 Dom을 조작하는 것보다 Innerhtml로 한번에 하는 것이 효율적.